### PR TITLE
Announcementの再取得の時間が正しくセットされていない

### DIFF
--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -64,7 +64,7 @@ export default class Announcements extends React.PureComponent {
   updateAnnouncements = (items) => {
     const validItems = unexpired(items, Date.now());
     this.setState({ items: validItems });
-    const timeout = validItems.isEmpty() ? ONE_DAY : new Date(validItems.get(0, 'expire')).getTime() - Date.now();
+    const timeout = validItems.isEmpty() ? ONE_DAY : new Date(validItems.get(0).get('expire')).getTime() - Date.now();
     this.timer = setTimeout(this.refresh, timeout);
   }
 


### PR DESCRIPTION
お知らせを表示するやつにバグを見つけてとりあえず潰した気がするんですが、JS何も分からんので他のバグ入れてそうなので、もともと実装した @osak さんに確認してほしいです。

# 問題

今の social.mikutter.hachune.net から notification.json?platform=mastodon に大量のアクセスがあり、検証したところWebから大量のアクセスをしているのが実際に確認できた

# 行った対策

現在は、mikutterのWebから notification.json が適切な時間キャッシュされるようにレスポンスヘッダを変更したので、サーバへのアクセスは十分に少なくなっていますが、依然として頻繁にアクセスを試行しています。

その後にAnnouncementsの実装を読んだので、ブラウザにキャッシュさせるとリアルタイムに更新されないということに気づいたため、Mastodon側の実装を変更するか、Webを元に戻すのどちらかの対策を取る予定です。

ひとまずこのpull requestでは、

- 現在短時間に大量のアクセスが行われていることを確認してもらって
- この変更がその修正として妥当であるか

を判断してほしいです。
