### PR TITLE
mikutterのお知らせを表示できるようにCSPを追加

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,6 +6,8 @@ base_host     = Rails.configuration.x.web_domain
 assets_host   = Rails.configuration.action_controller.asset_host
 assets_host ||= "http#{Rails.configuration.x.use_https ? 's' : ''}://#{base_host}"
 
+notification_host = 'https://mikutter.hachune.net'
+
 Rails.application.config.content_security_policy do |p|
   p.base_uri        :none
   p.default_src     :none
@@ -20,10 +22,10 @@ Rails.application.config.content_security_policy do |p|
   if Rails.env.development?
     webpacker_urls = %w(ws http).map { |protocol| "#{protocol}#{Webpacker.dev_server.https? ? 's' : ''}://#{Webpacker.dev_server.host_with_port}" }
 
-    p.connect_src :self, :blob, assets_host, Rails.configuration.x.streaming_api_base_url, *webpacker_urls
+    p.connect_src :self, :blob, assets_host, Rails.configuration.x.streaming_api_base_url, *webpacker_urls, notification_host
     p.script_src  :self, :unsafe_inline, :unsafe_eval, assets_host
   else
-    p.connect_src :self, :blob, assets_host, Rails.configuration.x.streaming_api_base_url
+    p.connect_src :self, :blob, assets_host, Rails.configuration.x.streaming_api_base_url, notification_host
     p.script_src  :self, assets_host
   end
 end


### PR DESCRIPTION
CSPが厳しくなってお知らせが表示されなくなっていたので、mikutter.hachune.netへアクセスできるようにPolicyを緩和しました。