### PR TITLE
notification.json 百裂拳の修正

### DIFF
--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -43,8 +43,12 @@ class Announcement extends React.PureComponent {
 
 }
 
-const unexpired = (items, now) => items.filter((entry) => new Date(entry.get('expire')).getTime() > now);
 const ONE_DAY = 24 * 60 * 60 * 1000;
+const unexpired = (items, now) => items.filter((entry) => new Date(entry.get('expire')).getTime() > now);
+const validTimeout = (items, now) => {
+  const nextTick =  items.isEmpty() ? ONE_DAY : new Date(items.get(0).get('expire')).getTime() - now;
+  return nextTick > ONE_DAY ? ONE_DAY : nextTick;
+};
 
 export default class Announcements extends React.PureComponent {
 
@@ -62,22 +66,18 @@ export default class Announcements extends React.PureComponent {
   }
 
   updateAnnouncements = (items) => {
-    const validItems = unexpired(items, Date.now());
+    const now = Date.now();
+    const validItems = unexpired(items, now);
     this.setState({ items: validItems });
-    const timeout = validItems.isEmpty() ? ONE_DAY : new Date(validItems.get(0).get('expire')).getTime() - Date.now();
+    const timeout = validTimeout(validItems, now);
     this.timer = setTimeout(this.refresh, timeout);
   };
 
   cancelPolling = () => {
-    if (this.timer !== null) {
-      clearTimeout(this.timer);
-      this.timer = null;
-    }
+    clearTimeout(this.timer);
   };
 
   refresh = () => {
-    this.timer = null;
-
     axios.get('https://mikutter.hachune.net/notification.json?platform=mastodon')
       .then(resp => this.updateAnnouncements(Immutable.fromJS(resp.data) || Immutable.List()))
       .catch(err => console.warn(err));

--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -47,7 +47,7 @@ const ONE_DAY = 24 * 60 * 60 * 1000;
 const unexpired = (items, now) => items.filter((entry) => new Date(entry.get('expire')).getTime() > now);
 const validTimeout = (items, now) => {
   const nextTick =  items.isEmpty() ? ONE_DAY : new Date(items.get(0).get('expire')).getTime() - now;
-  return nextTick > ONE_DAY ? ONE_DAY : nextTick;
+  return Math.min(nextTick, ONE_DAY);
 };
 
 export default class Announcements extends React.PureComponent {


### PR DESCRIPTION
expire と現在時刻との差分が 24.8 日以上空いている場合、
差分のミリ秒時間が setTimeout の delay(32bit signed int) をオーバーフローして負の値が入り、
即時実行されてしまうケースがあった。
これの対応のため、最長 delay を1日として処理するようにした。

また、これによって以下のケースにも対応可能となった。
* expire で setTimeout をしかけたが、その時間より直近のイベントが追加された場合に取得できない問題