### PR TITLE
restore sidekiq service to mastodon default settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,42 +70,12 @@ services:
       - db
       - redis
 
-  sidekiq_default_first:
+  sidekiq:
     build: .
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: bundle exec sidekiq -q default -q push
-    depends_on:
-      - db
-      - redis
-    networks:
-      - external_network
-      - internal_network
-    volumes:
-      - ./public/system:/mastodon/public/system
-
-  sidekiq_push_first:
-    build: .
-    image: tootsuite/mastodon
-    restart: always
-    env_file: .env.production
-    command: bundle exec sidekiq -q push -q default
-    depends_on:
-      - db
-      - redis
-    networks:
-      - external_network
-      - internal_network
-    volumes:
-      - ./public/system:/mastodon/public/system
-
-  sidekiq_all:
-    build: .
-    image: tootsuite/mastodon
-    restart: always
-    env_file: .env.production
-    command: bundle exec sidekiq -q default,1 -q push,1 -q mailers,1 -q pull,1
+    command: bundle exec sidekiq
     depends_on:
       - db
       - redis


### PR DESCRIPTION
sidekiqの設定をtootsuite/mastodonのデフォルトの設定に戻す。

デプロイ時に適当にdockerでscaleしていく。